### PR TITLE
feat(serilog): configure serilog to write to logs/app.log (#30)

### DIFF
--- a/Smart-car-sharing/Smart-car-sharing/App.xaml.cs
+++ b/Smart-car-sharing/Smart-car-sharing/App.xaml.cs
@@ -3,29 +3,48 @@ using SmartCarSharing.Data;
 using SmartCarSharing.Data.Services;
 using SmartCarSharing.Core.Services;
 using SmartCarSharingApp.UI.ViewModels;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace SmartCarSharingApp.UI
 {
     public partial class App : Application
     {
+        // We keep a reference to the factory so we can pass loggers to other services
+        public static ILoggerFactory? LoggerFactory { get; private set; }
+
         private AppDbContext _context;
 
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
 
-            // 1. Setup Database
+            // 1. Configure Serilog
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File("logs/app.log", rollingInterval: RollingInterval.Day)
+                .CreateLogger();
+
+            // 2. Create the wrapper that allows us to inject ILogger<T>
+            LoggerFactory = new SerilogLoggerFactory();
+
+            var appLoger = LoggerFactory.CreateLogger<App>();
+            appLoger.LogInformation("------------------");
+            appLoger.LogInformation("Smart Carsharing app Started");
+            appLoger.LogInformation("------------------");
+
+
+            // 3. Setup Database
             _context = new AppDbContext();
             // Ensure DB is created
             _context.Database.EnsureCreated();
 
-            // 2. Setup Services
+            // 4. Setup Services
             IAuthenticationService authService = new AuthenticationService(_context);
 
-            // 3. Setup Main ViewModel
             var mainViewModel = new MainViewModel(authService);
 
-            // 4. Show Window
             var mainWindow = new MainWindow
             {
                 DataContext = mainViewModel
@@ -37,6 +56,7 @@ namespace SmartCarSharingApp.UI
 
         protected override void OnExit(ExitEventArgs e)
         {
+            Log.CloseAndFlush();
             _context.Dispose();
             base.OnExit(e);
         }

--- a/Smart-car-sharing/Smart-car-sharing/SmartCarSharingApp.UI.csproj
+++ b/Smart-car-sharing/Smart-car-sharing/SmartCarSharingApp.UI.csproj
@@ -15,6 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### 🚀 Summary
Configured Serilog to write application logs to a file. This allows us to track errors and user actions.

### 📋 Changes
- Installed `Serilog.Sinks.File` and `Serilog.Extensions.Logging`.
- configured `App.xaml.cs` to initialize the logger on startup.
- Logs are now saved to `bin/Debug/.../logs/app.log`.
- Added a "Rolling Interval" so logs create a new file every day.

### 🧪 How to Test
1. Pull this branch.
2. Run the application.
3. Close the application.
4. Go to `bin/Debug/net8.0-windows/logs`.
5. Verify that `app.log` exists and contains the text "Smart CarSharing App Started".

### 🔗 Linked Issue
Closes #30
Related: SC-30