### PR TITLE
feat(tests): add unit tests for CarBuilder (#41)

### DIFF
--- a/Smart-car-sharing/Smart-car-sharing.Tests/CarBuilderTests.cs
+++ b/Smart-car-sharing/Smart-car-sharing.Tests/CarBuilderTests.cs
@@ -1,0 +1,51 @@
+﻿using Xunit;
+using SmartCarSharing.Core;
+using SmartCarSharing.Core.Builders;
+
+namespace SmartCarSharingApp.Tests
+{
+    public class CarBuilderTests
+    {
+        [Fact]
+        public void Build_ShouldCreateCar_WithCorrectProperties()
+        {
+            // Arrange
+            var builder = new CarBuilder();
+
+            // Act
+            Car result = builder
+                .WithModel("Tesla", "Model S")
+                .WithYear(2023)
+                .WithPrice(100m)
+                .WithLocation("Kyiv")
+                .Build();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Tesla", result.Make);
+            Assert.Equal("Model S", result.Model);
+            Assert.Equal(2023, result.Year);
+            Assert.Equal(100m, result.PricePerHour);
+            Assert.Equal("Kyiv", result.Location);
+        }
+
+        [Fact]
+        public void Build_ShouldReset_AfterCreatingCar()
+        {
+            // Arrange
+            var builder = new CarBuilder();
+
+            // Act
+            // Build first car
+            builder.WithModel("BMW", "X5").Build();
+
+            // Build second car (without setting properties)
+            Car emptyCar = builder.Build();
+
+            // Assert
+            // The builder should have reset to defaults (Id=0, null strings)
+            Assert.Equal(0, emptyCar.Id);
+            Assert.Null(emptyCar.Make);
+        }
+    }
+}


### PR DESCRIPTION
### 🚀 Summary
Added unit tests to verify the `CarBuilder` correctly generates and resets data. This ensures our seed data logic is reliable.

### 📋 Changes
- Created `CarBuilderTests.cs` in the Test project.
- Verified `Build()` correctly assigns all properties (Make, Model, Year, Price, Location).
- Verified `Reset()` clears the builder state between car creations.

### 🧪 How to Test
1. Open Test Explorer in Visual Studio.
2. Run `CarBuilderTests`.
3. Verify that both tests pass (Green).

### 🔗 Linked Issue
Closes #41 
Related: SC-39